### PR TITLE
feat: Dockerize and customize the explorer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# Use a Node.js image to build the app
+FROM node:20 AS builder
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the application code
+COPY . .
+
+# Use corepack to manage pnpm
+RUN corepack enable
+RUN corepack prepare pnpm@latest --activate
+
+# Build the application
+RUN pnpm i
+RUN pnpm run build
+
+# Use a lightweight web server to serve the app
+FROM nginx:alpine
+
+# Copy the build output to the Nginx HTML directory
+COPY --from=builder /app/apps/explorer/build /usr/share/nginx/html
+COPY --from=builder /app/docker-entrypoint.sh /docker-entrypoint.sh
+
+# Expose port 80
+EXPOSE 80
+
+# Some magic is happening in the entrypoint script, where we propagate
+# environment variables to the web application directly.
+# This is necessary to make the web application aware of the environment
+# variables set while running the container.
+#
+# Check docker-entrypoint.sh for details, which is a modified version
+# of the standard Nginx entrypoint script.
+CMD ["nginx", "-g", "daemon off;"]

--- a/apps/explorer/index.html
+++ b/apps/explorer/index.html
@@ -1,21 +1,34 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" type="image/png" sizes="16x16" href="/favicon16x16.png" />
-		<link rel="icon" type="image/png" sizes="32x32" href="/favicon32x32.png" />
-		<link rel="icon" type="image/png" sizes="192x192" href="/favicon192x192.png" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
-		<meta name="theme-color" content="#000000" />
-		<meta name="description" content="Explore transactions, objects, etc. of Sui network" />
-		<meta property="og:image" content="/SuiExplorerCard.png" />
-		<link rel="apple-touch-icon" href="/favicon192x192.png" />
-		<link rel="manifest" href="/manifest.json" />
-		<title>Sui Explorer</title>
-	</head>
-	<body>
-		<noscript>You need to enable JavaScript to run this app.</noscript>
-		<div id="root"></div>
-		<script type="module" src="/src/index.tsx"></script>
-	</body>
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon16x16.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon32x32.png" />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="192x192"
+      href="/favicon192x192.png"
+    />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1"
+    />
+    <meta name="theme-color" content="#000000" />
+    <meta
+      name="description"
+      content="Explore transactions, objects, etc. of Sui network"
+    />
+    <meta property="og:image" content="/SuiExplorerCard.png" />
+    <link rel="apple-touch-icon" href="/favicon192x192.png" />
+    <link rel="manifest" href="/manifest.json" />
+    <title>Sui Explorer</title>
+    <!-- inject our environment variables -->
+    <script src="/env-config.js"></script>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
 </html>

--- a/apps/explorer/public/env-config.js
+++ b/apps/explorer/public/env-config.js
@@ -1,0 +1,3 @@
+window.__ENV__ = {
+  SUI_RPC_URL: "https://fullnode.mainnet.sui.io",
+};

--- a/apps/explorer/src/context.ts
+++ b/apps/explorer/src/context.ts
@@ -3,42 +3,48 @@
 
 import { createContext, useContext, useMemo } from "react";
 // eslint-disable-next-line no-restricted-imports
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from "react-router-dom";
 
 import { Network } from "./utils/api/DefaultRpcClient";
-import { queryClient } from './utils/queryClient';
+import { queryClient } from "./utils/queryClient";
 
-export const DEFAULT_NETWORK =
-	import.meta.env.VITE_NETWORK || (import.meta.env.DEV ? Network.LOCAL : Network.MAINNET);
+// See also /apps/explorer/public/env-config.js
+// See also /docker-entrypoint.sh
+// See also /apps/explorer/src/types/env.d.ts
+export const DEFAULT_NETWORK = window.__ENV__?.SUI_RPC_URL || "";
 
 export const NetworkContext = createContext<
-	[Network | string, (network: Network | string) => void]
->(['', () => null]);
+  [Network | string, (network: Network | string) => void]
+>(["", () => null]);
 
 export function useNetworkContext() {
-	return useContext(NetworkContext);
+  return useContext(NetworkContext);
 }
 
+// TODO: Remove this flexibility.
 export function useNetwork(): [string, (network: Network | string) => void] {
-	const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
 
-	const network = useMemo(() => {
-		const networkParam = searchParams.get('network');
+  const network = useMemo(() => {
+    const networkParam = searchParams.get("network");
 
-		if (networkParam && (Object.values(Network) as string[]).includes(networkParam.toUpperCase())) {
-			return networkParam.toUpperCase();
-		}
+    if (
+      networkParam &&
+      (Object.values(Network) as string[]).includes(networkParam.toUpperCase())
+    ) {
+      return networkParam.toUpperCase();
+    }
 
-		return networkParam ?? DEFAULT_NETWORK;
-	}, [searchParams]);
+    return networkParam ?? DEFAULT_NETWORK;
+  }, [searchParams]);
 
-	const setNetwork = (network: Network | string) => {
-		// When resetting the network, we reset the query client at the same time:
-		queryClient.cancelQueries();
-		queryClient.clear();
+  const setNetwork = (network: Network | string) => {
+    // When resetting the network, we reset the query client at the same time:
+    queryClient.cancelQueries();
+    queryClient.clear();
 
-		setSearchParams({ network: network.toLowerCase() });
-	};
+    setSearchParams({ network: network.toLowerCase() });
+  };
 
-	return [network, setNetwork];
+  return [network, setNetwork];
 }

--- a/apps/explorer/src/types/env.d.ts
+++ b/apps/explorer/src/types/env.d.ts
@@ -1,0 +1,11 @@
+interface Window {
+  // This is needed in order to extend the window object with the __ENV__ object,
+  // which contains the environment variables.
+  //
+  // See also: /apps/explorer/public/env-config.js
+  // See also: /docker-entrypoint.sh
+  __ENV__?: {
+    SUI_RPC_URL?: string;
+    // Add other runtime config variables here
+  };
+}

--- a/apps/explorer/src/ui/header/NetworkSelect.tsx
+++ b/apps/explorer/src/ui/header/NetworkSelect.tsx
@@ -8,278 +8,235 @@
  * now we are including App UI Components in the base UI component directory.
  */
 
-import { autoUpdate, flip, FloatingPortal, offset, shift, useFloating } from '@floating-ui/react';
-import { Popover } from '@headlessui/react';
-import { useZodForm } from '@mysten/core';
-import { HamburgerRest16 } from '@mysten/icons';
-import { Text } from '@mysten/ui';
-import clsx from 'clsx';
-import { AnimatePresence, motion } from 'framer-motion';
-import { useEffect, useState } from 'react';
-import { z } from 'zod';
+import {
+  autoUpdate,
+  flip,
+  FloatingPortal,
+  offset,
+  shift,
+  useFloating,
+} from "@floating-ui/react";
+import { Popover } from "@headlessui/react";
+import { useZodForm } from "@mysten/core";
+import { HamburgerRest16 } from "@mysten/icons";
+import { Text } from "@mysten/ui";
+import clsx from "clsx";
+import { AnimatePresence, motion } from "framer-motion";
+import { useEffect, useState } from "react";
+import { z } from "zod";
 
-import { NavItem } from './NavItem';
-import { ReactComponent as CheckIcon } from '../icons/check_16x16.svg';
-import { ReactComponent as MenuIcon } from '../icons/menu.svg';
+import { NavItem } from "./NavItem";
+import { ReactComponent as CheckIcon } from "../icons/check_16x16.svg";
+import { ReactComponent as MenuIcon } from "../icons/menu.svg";
 
-import type { ComponentProps, ReactNode } from 'react';
+import type { ComponentProps, ReactNode } from "react";
 
 export interface NetworkOption {
-	id: string;
-	label: string;
+  id: string;
+  label: string;
 }
 
 export interface NetworkSelectProps {
-	networks: NetworkOption[];
-	value: string;
-	version?: number | string;
-	binaryVersion?: string;
-	onChange(networkId: string): void;
+  networks: NetworkOption[];
+  value: string;
+  version?: number | string;
+  binaryVersion?: string;
+  onChange(networkId: string): void;
 }
 
 enum NetworkState {
-	UNSELECTED = 'UNSELECTED',
-	PENDING = 'PENDING',
-	SELECTED = 'SELECTED',
+  UNSELECTED = "UNSELECTED",
+  PENDING = "PENDING",
+  SELECTED = "SELECTED",
 }
 
-interface SelectableNetworkProps extends ComponentProps<'div'> {
-	state: NetworkState;
-	children: ReactNode;
-	onClick(): void;
+interface SelectableNetworkProps extends ComponentProps<"div"> {
+  state: NetworkState;
+  children: ReactNode;
+  onClick(): void;
 }
 
-function SelectableNetwork({ state, children, onClick, ...props }: SelectableNetworkProps) {
-	return (
-		<div
-			role="button"
-			onClick={onClick}
-			className={clsx(
-				'flex items-start gap-3 rounded-md px-1.25 py-2 text-body font-semibold hover:bg-gray-40 ui-active:bg-gray-40',
-				state !== NetworkState.UNSELECTED ? 'text-steel-darker' : 'text-steel-dark',
-			)}
-			{...props}
-		>
-			<CheckIcon
-				className={clsx('flex-shrink-0', {
-					'text-success': state === NetworkState.SELECTED,
-					'text-steel': state === NetworkState.PENDING,
-					'text-gray-45': state === NetworkState.UNSELECTED,
-				})}
-			/>
-			<div className="mt-px">
-				<Text
-					variant="body/semibold"
-					color={state === NetworkState.SELECTED ? 'steel-darker' : 'steel-dark'}
-				>
-					{children}
-				</Text>
-			</div>
-		</div>
-	);
+function SelectableNetwork({
+  state,
+  children,
+  onClick,
+  ...props
+}: SelectableNetworkProps) {
+  return (
+    <div
+      role="button"
+      onClick={onClick}
+      className={clsx(
+        "flex items-start gap-3 rounded-md px-1.25 py-2 text-body font-semibold hover:bg-gray-40 ui-active:bg-gray-40",
+        state !== NetworkState.UNSELECTED
+          ? "text-steel-darker"
+          : "text-steel-dark"
+      )}
+      {...props}
+    >
+      <CheckIcon
+        className={clsx("flex-shrink-0", {
+          "text-success": state === NetworkState.SELECTED,
+          "text-steel": state === NetworkState.PENDING,
+          "text-gray-45": state === NetworkState.UNSELECTED,
+        })}
+      />
+      <div className="mt-px">
+        <Text
+          variant="body/semibold"
+          color={
+            state === NetworkState.SELECTED ? "steel-darker" : "steel-dark"
+          }
+        >
+          {children}
+        </Text>
+      </div>
+    </div>
+  );
 }
 
 const CustomRPCSchema = z.object({
-	url: z.string().url(),
+  url: z.string().url(),
 });
 
 function CustomRPCInput({
-	value,
-	onChange,
+  value,
+  onChange,
 }: {
-	value: string;
-	onChange(networkUrl: string): void;
+  value: string;
+  onChange(networkUrl: string): void;
 }) {
-	const { register, handleSubmit, formState } = useZodForm({
-		schema: CustomRPCSchema,
-		mode: 'all',
-		defaultValues: {
-			url: value,
-		},
-	});
+  const { register, handleSubmit, formState } = useZodForm({
+    schema: CustomRPCSchema,
+    mode: "all",
+    defaultValues: {
+      url: value,
+    },
+  });
 
-	const { errors, isDirty, isValid } = formState;
+  const { errors, isDirty, isValid } = formState;
 
-	return (
-		<form
-			onSubmit={handleSubmit((values) => {
-				onChange(values.url);
-			})}
-			className="relative flex items-center rounded-md"
-		>
-			<input
-				{...register('url')}
-				type="text"
-				className={clsx(
-					'block w-full rounded-md border p-3 pr-16 shadow-sm outline-none',
-					errors.url ? 'border-issue-dark text-issue-dark' : 'border-gray-65 text-gray-90',
-				)}
-			/>
+  return (
+    <form
+      onSubmit={handleSubmit((values) => {
+        onChange(values.url);
+      })}
+      className="relative flex items-center rounded-md"
+    >
+      <input
+        {...register("url")}
+        type="text"
+        className={clsx(
+          "block w-full rounded-md border p-3 pr-16 shadow-sm outline-none",
+          errors.url
+            ? "border-issue-dark text-issue-dark"
+            : "border-gray-65 text-gray-90"
+        )}
+      />
 
-			<div className="absolute inset-y-0 right-0 flex flex-col justify-center px-3">
-				<button
-					disabled={!isDirty || !isValid}
-					type="submit"
-					className="flex items-center justify-center rounded-full bg-gray-90 px-2 py-1 text-captionSmall font-semibold uppercase text-white transition disabled:bg-gray-45 disabled:text-gray-65"
-				>
-					Save
-				</button>
-			</div>
-		</form>
-	);
+      <div className="absolute inset-y-0 right-0 flex flex-col justify-center px-3">
+        <button
+          disabled={!isDirty || !isValid}
+          type="submit"
+          className="flex items-center justify-center rounded-full bg-gray-90 px-2 py-1 text-captionSmall font-semibold uppercase text-white transition disabled:bg-gray-45 disabled:text-gray-65"
+        >
+          Save
+        </button>
+      </div>
+    </form>
+  );
 }
 
 function NetworkVersion({
-	label,
-	version,
-	binaryVersion,
+  label,
+  version,
+  binaryVersion,
 }: {
-	label: string;
-	version: number | string;
-	binaryVersion: string;
+  label: string;
+  version: number | string;
+  binaryVersion: string;
 }) {
-	return (
-		<div className="flex flex-col justify-between gap-1 px-4 py-3">
-			<Text variant="subtitleSmall/medium" color="steel-dark">
-				Sui {label}
-			</Text>
-			<Text variant="subtitleSmall/medium" color="steel-dark">
-				v{binaryVersion} (Protocol {version})
-			</Text>
-		</div>
-	);
+  return (
+    <div className="flex flex-col justify-between gap-1 px-4 py-3">
+      <Text variant="subtitleSmall/medium" color="steel-dark">
+        Sui {label}
+      </Text>
+      <Text variant="subtitleSmall/medium" color="steel-dark">
+        v{binaryVersion} (Protocol {version})
+      </Text>
+    </div>
+  );
 }
 
-function NetworkSelectPanel({ networks, onChange, value }: Omit<NetworkSelectProps, 'version'>) {
-	const isCustomNetwork = !networks.find(({ id }) => id === value);
-	const [customOpen, setCustomOpen] = useState(isCustomNetwork);
+function NetworkSelectPanel({
+  networks,
+  onChange,
+  value,
+}: Omit<NetworkSelectProps, "version">) {
+  const isCustomNetwork = !networks.find(({ id }) => id === value);
+  const [customOpen, setCustomOpen] = useState(isCustomNetwork);
 
-	useEffect(() => {
-		setCustomOpen(isCustomNetwork);
-	}, [isCustomNetwork]);
+  useEffect(() => {
+    setCustomOpen(isCustomNetwork);
+  }, [isCustomNetwork]);
 
-	return (
-		<>
-			{networks.map((network) => (
-				<SelectableNetwork
-					key={network.id}
-					state={
-						!customOpen && value === network.id ? NetworkState.SELECTED : NetworkState.UNSELECTED
-					}
-					onClick={() => {
-						onChange(network.id);
-					}}
-				>
-					{network.label}
-				</SelectableNetwork>
-			))}
+  return (
+    <>
+      {networks.map((network) => (
+        <SelectableNetwork
+          key={network.id}
+          state={
+            !customOpen && value === network.id
+              ? NetworkState.SELECTED
+              : NetworkState.UNSELECTED
+          }
+          onClick={() => {
+            onChange(network.id);
+          }}
+        >
+          {network.label}
+        </SelectableNetwork>
+      ))}
 
-			<SelectableNetwork
-				state={
-					isCustomNetwork
-						? NetworkState.SELECTED
-						: customOpen
-						? NetworkState.PENDING
-						: NetworkState.UNSELECTED
-				}
-				onClick={() => setCustomOpen(true)}
-			>
-				Custom RPC URL
-				{customOpen && (
-					<div className="mt-3">
-						<CustomRPCInput value={isCustomNetwork ? value : ''} onChange={onChange} />
-					</div>
-				)}
-			</SelectableNetwork>
-		</>
-	);
+      <SelectableNetwork
+        state={
+          isCustomNetwork
+            ? NetworkState.SELECTED
+            : customOpen
+            ? NetworkState.PENDING
+            : NetworkState.UNSELECTED
+        }
+        onClick={() => setCustomOpen(true)}
+      >
+        Custom RPC URL
+        {customOpen && (
+          <div className="mt-3">
+            <CustomRPCInput
+              value={isCustomNetwork ? value : ""}
+              onChange={onChange}
+            />
+          </div>
+        )}
+      </SelectableNetwork>
+    </>
+  );
 }
 
 function ResponsiveIcon() {
-	return (
-		<div>
-			<HamburgerRest16 className="hidden md:block" />
-			<MenuIcon className="block md:hidden" />
-		</div>
-	);
+  return (
+    <div>
+      <HamburgerRest16 className="hidden md:block" />
+      <MenuIcon className="block md:hidden" />
+    </div>
+  );
 }
 
 export function NetworkSelect({
-	networks,
-	value,
-	version,
-	binaryVersion,
-	onChange,
+  networks,
+  value,
+  version,
+  binaryVersion,
+  onChange,
 }: NetworkSelectProps) {
-	const { x, y, refs, strategy } = useFloating({
-		placement: 'bottom-end',
-		middleware: [offset(5), flip(), shift()],
-		whileElementsMounted: autoUpdate,
-	});
-
-	const selected = networks.find(({ id }) => id === value);
-
-	return (
-		<Popover>
-			{({ open, close }) => (
-				<>
-					<Popover.Button ref={refs.setReference} as={NavItem} afterIcon={<ResponsiveIcon />}>
-						<div className="hidden md:block">
-							<Text variant="body/semibold" color="hero-darkest">
-								{selected?.label || 'Custom'}
-							</Text>
-						</div>
-					</Popover.Button>
-					<FloatingPortal>
-						<AnimatePresence>
-							{open && (
-								<Popover.Panel
-									static
-									ref={refs.setFloating}
-									as={motion.div}
-									initial={{
-										opacity: 0,
-										scale: 0.95,
-									}}
-									animate={{
-										opacity: 1,
-										scale: 1,
-									}}
-									exit={{
-										opacity: 0,
-										scale: 0.95,
-									}}
-									transition={{ duration: 0.15 }}
-									className="z-20 flex w-52 flex-col gap-2 rounded-lg bg-white/80 px-3 py-4 shadow-lg backdrop-blur focus:outline-none"
-									style={{
-										position: strategy,
-										top: y ?? 0,
-										left: x ?? 0,
-									}}
-								>
-									<NetworkSelectPanel
-										networks={networks}
-										value={value}
-										onChange={(network) => {
-											onChange(network);
-											close();
-										}}
-									/>
-									{!!value && version && binaryVersion ? (
-										<div className="-mx-3 -mb-4 mt-2 rounded-b-lg bg-hero-darkest/5">
-											<NetworkVersion
-												label={selected?.label ?? 'Custom RPC'}
-												binaryVersion={binaryVersion}
-												version={version}
-											/>
-										</div>
-									) : null}
-								</Popover.Panel>
-							)}
-						</AnimatePresence>
-					</FloatingPortal>
-				</>
-			)}
-		</Popover>
-	);
+  return <></>;
 }

--- a/apps/explorer/tsconfig.json
+++ b/apps/explorer/tsconfig.json
@@ -1,24 +1,25 @@
 {
-	"compilerOptions": {
-		"target": "ES2020",
-		"lib": ["dom", "dom.iterable", "esnext"],
-		"allowJs": true,
-		"skipLibCheck": true,
-		"esModuleInterop": true,
-		"allowSyntheticDefaultImports": true,
-		"strict": true,
-		"forceConsistentCasingInFileNames": true,
-		"noFallthroughCasesInSwitch": true,
-		"module": "esnext",
-		"moduleResolution": "node",
-		"resolveJsonModule": true,
-		"isolatedModules": true,
-		"noEmit": true,
-		"jsx": "react-jsx",
-		"baseUrl": ".",
-		"paths": {
-			"~/*": ["./src/*"]
-		}
-	},
-	"include": ["src", "tests"]
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./src/*"]
+    },
+    "typeRoots": ["node_modules/@types", "src/types"]
+  },
+  "include": ["src", "tests"]
 }

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# vim:sw=4:ts=4:et
+
+set -ex
+
+entrypoint_log() {
+    if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
+        echo "$@"
+    fi
+}
+
+if [ "$1" = "nginx" ] || [ "$1" = "nginx-debug" ]; then
+    if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
+        entrypoint_log "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
+
+        entrypoint_log "$0: Looking for shell scripts in /docker-entrypoint.d/"
+        find "/docker-entrypoint.d/" -follow -type f -print | sort -V | while read -r f; do
+            case "$f" in
+            *.envsh)
+                if [ -x "$f" ]; then
+                    entrypoint_log "$0: Sourcing $f"
+                    . "$f"
+                else
+                    # warn on shell scripts without exec bit
+                    entrypoint_log "$0: Ignoring $f, not executable"
+                fi
+                ;;
+            *.sh)
+                if [ -x "$f" ]; then
+                    entrypoint_log "$0: Launching $f"
+                    "$f"
+                else
+                    # warn on shell scripts without exec bit
+                    entrypoint_log "$0: Ignoring $f, not executable"
+                fi
+                ;;
+            *) entrypoint_log "$0: Ignoring $f" ;;
+            esac
+        done
+
+        entrypoint_log "$0: Configuration complete; ready for start up"
+    else
+        entrypoint_log "$0: No files found in /docker-entrypoint.d/, skipping configuration"
+    fi
+fi
+
+cat <<EOF >/usr/share/nginx/html/env-config.js
+window.__ENV__ = {
+  SUI_RPC_URL: "${SUI_RPC_URL}",
+};
+EOF
+
+echo
+echo /usr/share/nginx/html/env-config.js:
+cat /usr/share/nginx/html/env-config.js
+
+echo
+echo Environment variables:
+env
+
+if [ -z "${SUI_RPC_URL}" ]; then
+    echo
+    echo "SUI_RPC_URL is not set."
+fi
+
+echo
+echo Running: "$@"
+
+exec "$@"

--- a/justfile
+++ b/justfile
@@ -1,0 +1,64 @@
+name := 'sui-explorer'
+version := 'latest'
+tag := name + ':' + version
+port := '8080'
+sui_rpc_url := 'https://fullnode.testnet.sui.io'
+
+
+@_default:
+    just --list
+
+alias build := docker-build
+# Build the explorer image
+docker-build:
+    docker build -t {{tag}} .
+
+alias start := docker-start
+# Run the explorer image
+docker-start:
+    docker run --name {{name}} --rm -d -p {{port}}:80 -e SUI_RPC_URL={{sui_rpc_url}} {{tag}}
+
+alias stop := docker-stop
+# Stop the explorer container
+docker-stop:
+    #!/usr/bin/env bash
+    docker kill {{name}} || true
+    docker rm {{name}} || true
+
+alias restart := docker-restart
+# Restart the explorer container
+docker-restart:
+    #!/usr/bin/env bash
+    just docker-stop || true
+    just docker-start
+
+# Run a shell using the explorer image
+docker-image-shell:
+    docker run -it --rm --name {{name}}-shell {{name}}:latest sh
+
+alias shell := docker-container-shell
+# Run (exec) a shell in the explorer container
+docker-container-shell:
+    docker exec -it {{name}} sh
+
+alias env-config := docker-container-env-config
+# Show env-config.js in the explorer container
+docker-container-env-config:
+    docker exec -it {{name}} cat /usr/share/nginx/html/env-config.js
+
+
+alias open := browser-open
+# Open the explorer in the default browser
+browser-open:
+    #!/usr/bin/env bash
+    if command -v xdg-open &> /dev/null
+    then
+        xdg-open http://localhost:{{port}}/
+    elif command -v open &> /dev/null
+    then
+        open http://localhost:{{port}}/
+    else
+        echo "No suitable browser found to open the URL."
+        exit 1
+    fi
+


### PR DESCRIPTION
Notes:

* Create an appropriate Dockerfile and supporting scripts.
* Use `nginx` to serve the web app of the explorer.
* Introduce the `SUI_RPC_URL` environment variable, which is passed to the web page as the network URL the explorer should connect to. It's default value points to Sui mainnet. This variable is communicated to the web app via injecting it in a JS file the web app has access to (See: `apps/explorer/public/env-config.js`).
* Use a custom `docker-entrypoint.sh`, which is a modified version of the script that already exists in the respective "parent" docker image.
* The actual changes in the codebase are fewer than what a diff shows, because of some editor (VSCode) auto-formatting.
* We essentially delete from the web page the network selector, but you can still override the network by using the `network` URL parameter.